### PR TITLE
Configure rootless builder agent

### DIFF
--- a/resources/agent.buildconfig.yaml
+++ b/resources/agent.buildconfig.yaml
@@ -13,6 +13,9 @@ spec:
   source:
     dockerfile: |
       FROM registry.redhat.io/rhel8/dotnet-60-runtime:latest
+      ENV _BUILDAH_STARTED_IN_USERNS="" \
+          BUILDAH_ISOLATION=chroot \
+          STORAGE_DRIVER=vfs
 
       USER root
       COPY start.sh .
@@ -20,7 +23,13 @@ spec:
           curl $AZP_AGENT_PACKAGE_LATEST_URL --output vsts-agent-linux-x64.tar.gz && \
           tar zxvf vsts-agent-linux-x64.tar.gz && \
           rm vsts-agent-linux-x64.tar.gz && \
-          chmod 755 *.sh && chown -R default:root .
+          chmod 755 *.sh && chown -R default:root . && \
+          usermod --add-subuids 100000-165535 default && \
+          usermod --add-subgids 100000-165535 default && \
+          touch /etc/containers/nodocker && \
+          chmod u-s /usr/bin/new[gu]idmap && \
+          setcap cap_setuid+eip /usr/bin/newuidmap && \
+          setcap cap_setgid+eip /usr/bin/newgidmap
       USER 1001
       ENTRYPOINT ["./start.sh"]
     configMaps:

--- a/resources/agent.deployment.yaml
+++ b/resources/agent.deployment.yaml
@@ -60,6 +60,6 @@ spec:
           ports:
           - containerPort: 8080
           securityContext:
-            privileged: true
+            runAsUser: 1001
       serviceAccount: azure-build-sa
       serviceAccountName: azure-build-sa

--- a/resources/nonroot-builder.scc.yaml
+++ b/resources/nonroot-builder.scc.yaml
@@ -1,0 +1,37 @@
+# https://www.redhat.com/sysadmin/rootless-podman-jenkins-openshift
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: nonroot-builder provides all features of the nonroot
+      SCC but allows users to run with any non-root UID and multiple namespaces for 
+      nonroot building of images with podman and buildah
+  name: nonroot-builder
+priority: 5
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+runAsUser:
+  type: MustRunAs
+  uid: 1001
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/resources/start.sh
+++ b/resources/start.sh
@@ -51,7 +51,7 @@ source ./env.sh
 print_header "Configuring Azure Pipelines agent..."
 
 # Determine if proxy variables are set
-if [ -n "$AZP_PROXY_ENV" ]; then
+if [ -z "$AZP_PROXY_ENV" ]; then
   export http_proxy=$AZP_PROXY_ENV
 fi
 
@@ -95,6 +95,8 @@ else
     --replace \
     --acceptTeeEula & wait $!
 fi
+
+unset AZP_PROXY_URL AZP_PROXY_USERNAME AZP_PROXY_PASSWORD AZP_PROXY_ENV
 
 print_header "Running Azure Pipelines agent..."
 


### PR DESCRIPTION
Updated instructions to configure rootless builder agent.  Followed some articles:
- How to configure rootless podman with SCC: https://www.redhat.com/sysadmin/rootless-podman-jenkins-openshift
- How to build rootless podman builder: https://www.redhat.com/sysadmin/rootless-podman-jenkins-openshift
- Intro to rootless podman: https://www.redhat.com/sysadmin/controlling-access-rootless-podman-users
- Various ways of running podman in k8s: https://www.redhat.com/sysadmin/podman-inside-kubernetes
- Rootless containers with --user flag: https://www.redhat.com/sysadmin/user-flag-rootless-containers
- Debugging (checking my work) on issues with rootless podman: https://www.redhat.com/sysadmin/debug-rootless-podman-mounted-volumes
- Pulling images with rootless podman: https://www.redhat.com/sysadmin/rootless-podman
- Rootless overlay support (moving away from fuse-overlayfs): https://www.redhat.com/sysadmin/podman-rootless-overlay
